### PR TITLE
Update Aggregation.php -- filters function

### DIFF
--- a/src/Aggregation.php
+++ b/src/Aggregation.php
@@ -207,17 +207,15 @@ class Aggregation
     /**
      * @param $namespace
      * @param $filters
-     * @param $aggs
      * @return array
      */
-    public function filters($namespace,$filters,$aggs)
+    public function filters($namespace,$filters)
     {
         return [
             $namespace => [
                 'filters' => [
                     'filters' => $filters
-                ],
-                'aggs' => $aggs
+                ]
             ]
         ];
     }


### PR DESCRIPTION
Removed $aggs parameter from filters function.  It does not currently exist in the filters aggregation in Elasticsearch.  No need for the parameter in the builder (and it is breaking the request).