### PR TITLE
Update Aggregation.php

### DIFF
--- a/src/Aggregation.php
+++ b/src/Aggregation.php
@@ -412,9 +412,9 @@ class Aggregation
         return [
             $namespace => [
                 'nested' => [
-                    'path' => $path,
-                    'aggs' => $aggs
-                ]
+                    'path' => $path
+                ],
+                'aggs' => $aggs
             ]
         ];
     }


### PR DESCRIPTION
updated the 'aggs' portion of the nested function (in Aggregation.php) so that it is nested in the namespace array rather than in the namespace['nested'] array (which follows the most current Elasticsearch documentation).