### PR TITLE
Hotfix/update decay functions in function score

### DIFF
--- a/src/ElasticBuilder.php
+++ b/src/ElasticBuilder.php
@@ -480,35 +480,6 @@ class ElasticBuilder
 
     /**
      * @param $field
-     * @param $origin
-     * @param $offset
-     * @param $scale
-     * @param int $weight
-     * @return array
-     */
-    public function gauss($field,$origin,$offset,$scale,$weight=1)
-    {
-
-        $args = [
-            'origin' => $origin,
-            'scale' => $scale
-        ];
-
-        if(!empty($offset))
-        {
-            $args = array_merge($args,['offset'=>$offset]);
-        }
-
-        return [
-            'gauss' => [
-                $field => $args
-            ],
-            'weight' => $weight
-        ];
-    }
-
-    /**
-     * @param $field
      * @param $top_left
      * @param $bottom_right
      * @return array

--- a/src/ElasticBuilder.php
+++ b/src/ElasticBuilder.php
@@ -28,16 +28,48 @@ use Illuminate\Support\Collection as BaseCollection;
  */
 class ElasticBuilder
 {
+    /**
+     * @var Elastic
+     */
+    public $elastic;
+
+    /**
+     * @var
+     */
+    public $index;
+
+    /**
+     * @var string specify the handler used by \Elastic\Client
+     */
+    protected $handler;
+
+    /**
+     * @var array the client parameters to be used by the client handler
+     */
+    private $client = [];
+
+    /**
+     * @var int the offset of the results window
+     */
+    private $from = 0;
+
+    /**
+     * @var int the size of the results window
+     */
+    private $size = 10;
 
     /**
      * Create a new engine instance.
      *
      * @param  \Elasticsearch\Client  $elastic
+     * @param string $index
+     * @param string $handler the handler
      * @return void
      */
-    public function __construct(Elastic $elastic, $index)
+    public function __construct(Elastic $elastic, $index, $handler = 'curl')
     {
         $this->elastic = $elastic;
+        $this->handler = $handler;
         $this->index = $index;
     }
 
@@ -481,19 +513,107 @@ class ElasticBuilder
     }
 
     /**
+     * Set the offset of the results window
+     *
+     * @param int $offset the offset of the results window
+     */
+    public function from($offset = 0){
+
+        if (is_integer($offset)) {
+
+            $this->from = $offset;
+
+        }
+
+    }
+
+    /**
+     * Set the result window size
+     *
+     * @param int $hits the number of hits in the results window
+     */
+    public function size($hits = 10){
+
+        if (is_integer($hits)){
+
+            $this->size = $hits;
+
+        }
+
+    }
+
+    /**
+     * Set the client parameters
+     *
+     * @param array $client
+     */
+    public function client_parameters($client = []){
+
+        if($this->handler == 'curl') {
+
+            if (empty($client)) {
+
+                $this->client = [
+                    'curl' => [
+                        CURLOPT_HTTPHEADER => [
+                            'Content-type: application/json'
+                        ]
+                    ]
+                ];
+
+            } else if (!empty($client)) {
+
+                $this->client = $client;
+
+                $needs_content_type = true;
+
+                if(!empty($this->client['curl'][CURLOPT_HTTPHEADER]) && is_array($this->client['curl'][CURLOPT_HTTPHEADER])){
+
+                    foreach($this->client['curl'][CURLOPT_HTTPHEADER] as $headerParameter){
+
+                        if (strpos(strtolower($headerParameter), 'content-type:') !== false) {
+                            $needs_content_type = false;
+                            continue;
+                        }
+
+                    }
+
+                }
+
+                if ( $needs_content_type === true ) {
+
+                    $this->client['curl'][CURLOPT_HTTPHEADER][] = 'Content-type: application/json';
+
+                }
+            }
+        }
+
+        //allow for custom client parameters on non-curl handlers
+        else if (!empty($client) && is_array($client)) {
+
+            $query['client'] = $client;
+        }
+    }
+
+    /**
      * @param $params
      * @param $type
      * @return array
      */
     public function search($params, $type)
     {
+
         $query = [
             'index' => $this->index,
             'type' => $type,
+            'from' => $this->from,
+            'size' => $this->size,
+            'client' => $this->client,
             'body' => [
                 'query' =>  $params
             ]
         ];
+
         try{
             $search = $this->elastic->search($query);
             return $search;

--- a/src/Query/FunctionScore.php
+++ b/src/Query/FunctionScore.php
@@ -82,4 +82,101 @@ class FunctionScore extends Query
 
         return $this;
     }
+
+    /**
+     * score via functions which are determined against a distance value
+     *
+     * @param string $decayFunction the type of decay function to be used for calculation ('gauss'|'exp'|'linear')
+     * @param string $field the field used for calculation, the type of this field determines whether origin is required or not by Elasticsearch
+     * @param string $scale defines the distance from origin plus the offset at which computed score equals the decay
+     * @param mixed $origin note: Required (by Elasticsearch) for Geo and Numeric Field Types
+     * @param string $offset if set, the decay function will only begin computing decay functions with distances greater than the offset
+     * @param string $decay how documents are scored at the distance provided via scale
+     * @param int|float|null $weight the score applied to this function
+     * @param string $multiValueMode if more than one origin is given, this value is used to determine the distance ('min'|'max'|'avg'|'sum')
+     * @return FunctionScore
+     */
+    private function functions_decay($decayFunction, $field, $scale, $origin = '', $offset = '', $decay = '', $weight = null, $multiValueMode = 'min')
+    {
+
+        $new_decay = [
+            $decayFunction => [
+                $field => [
+                    'decay' => $decay,
+                    'multi_value_mode' => $multiValueMode,
+                    'offset' => $offset,
+                    'scale' => $scale,
+                ]
+            ]
+        ];
+
+        if (!empty($origin)) {
+            $new_decay[$decay][$field]['origin'] = $origin;
+        }
+
+        if(!is_null($weight)){
+            $new_decay['weight'] = $weight;
+        }
+
+        $this->query['function_score']['functions'][] = $new_decay;
+
+        return $this;
+    }
+
+    /**
+     * a decay function based (a.k.a. normal decay)
+     *
+     * @param string $field the field used for calculation, the type of this field determines whether origin is required or not by Elasticsearch
+     * @param string $scale defines the distance from origin plus the offset at which computed score equals the decay
+     * @param mixed $origin note: Required (by Elasticsearch) for Geo and Numeric Field Types
+     * @param string $offset if set, the decay function will only begin computing decay functions with distances greater than the offset
+     * @param string $decay how documents are scored at the distance provided via scale
+     * @param int|float|null $weight the score applied to this function
+     * @param string $multiValueMode if more than one origin is given, this value is used to determine the distance ('min'|'max'|'avg'|'sum')
+     * @return FunctionScore
+     */
+    public function gauss($field,$scale,$origin = '',$offset = '0',$decay = '0.5', $weight = null, $multiValueMode = 'min')
+    {
+
+        return $this->functions_decay('gauss', $field, $scale, $origin, $offset, $decay, $weight, $multiValueMode);
+
+    }
+
+    /**
+     * a decay function based (a.k.a. exponential decay)
+     *
+     * @param string $field the field used for calculation, the type of this field determines whether origin is required or not by Elasticsearch
+     * @param string $scale defines the distance from origin plus the offset at which computed score equals the decay
+     * @param mixed $origin note: Required (by Elasticsearch) for Geo and Numeric Field Types
+     * @param string $offset if set, the decay function will only begin computing decay functions with distances greater than the offset
+     * @param string $decay how documents are scored at the distance provided via scale
+     * @param int|float|null $weight the score applied to this function
+     * @param string $multiValueMode if more than one origin is given, this value is used to determine the distance ('min'|'max'|'avg'|'sum')
+     * @return FunctionScore
+     */
+    public function exp($field,$scale,$origin = '',$offset = '0',$decay = '0.5', $weight = null, $multiValueMode = 'min')
+    {
+
+        return $this->functions_decay('exp', $field, $scale, $origin, $offset, $decay, $weight, $multiValueMode);
+
+    }
+
+    /**
+     * a decay function based (a.k.a. exponential decay)
+     *
+     * @param string $field the field used for calculation, the type of this field determines whether origin is required or not by Elasticsearch
+     * @param string $scale defines the distance from origin plus the offset at which computed score equals the decay
+     * @param mixed $origin note: Required (by Elasticsearch) for Geo and Numeric Field Types
+     * @param string $offset if set, the decay function will only begin computing decay functions with distances greater than the offset
+     * @param string $decay how documents are scored at the distance provided via scale
+     * @param int|float|null $weight the score applied to this function
+     * @param string $multiValueMode if more than one origin is given, this value is used to determine the distance ('min'|'max'|'avg'|'sum')
+     * @return FunctionScore
+     */
+    public function linear($field,$scale,$origin = '',$offset = '0',$decay = '0.5', $weight = null, $multiValueMode = 'min')
+    {
+
+        return $this->functions_decay('linear', $field, $scale, $origin, $offset, $decay, $weight, $multiValueMode);
+
+    }
 }


### PR DESCRIPTION
HOTFIX: to bring decay functions into the Function Score Class
- move gauss from ElasticBuilder to FunctionScore because it only exists as a Function Score function (technically not a breaking change because it should have been moved with creation of the FunctionScore class)
- add functions_decay private function to the FunctionScore class which builds the decay functions used in a Function Score Query
- add gauss public function which is a specific type of a decay function score function
- add exp public function which is a specific type of decay function score function
- add linear public function which is a specific type of decay function score function