### PR TITLE
Update to PHP 8.0 compatibility

### DIFF
--- a/src/Aggregation.php
+++ b/src/Aggregation.php
@@ -20,13 +20,13 @@ class Aggregation
 {
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @param int $size
-     * @param array $order
+     * @param array|null $order
      * @return array
      */
-    public function terms($namespace,$field,$size=10,$order=null)
+    public function terms(string $namespace, string $field, int $size=10, array $order = null): array
     {
         $terms = [
             'field' => $field,
@@ -35,7 +35,7 @@ class Aggregation
 
         if(!empty($order))
         {
-            array_merge($terms,['order' => $order]);
+            $terms = array_merge($terms,['order' => $order]);
         }
 
         return [
@@ -46,11 +46,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-    public function stats($namespace,$field)
+    public function stats(string $namespace, string $field): array
     {
         return [
             $namespace => [
@@ -62,11 +62,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-    public function extended_stats($namespace,$field)
+    public function extended_stats(string $namespace, string $field): array
     {
         return [
             $namespace => [
@@ -78,11 +78,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-    public function min($namespace,$field)
+    public function min(string $namespace, string $field): array
     {
         return [
             $namespace => [
@@ -94,11 +94,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-    public function max($namespace,$field)
+    public function max(string $namespace, string $field): array
     {
         return [
             $namespace => [
@@ -110,11 +110,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-    public function avg($namespace,$field)
+    public function avg(string $namespace, string $field): array
     {
         return [
             $namespace => [
@@ -126,11 +126,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-    public function cardinality($namespace,$field)
+    public function cardinality(string $namespace, string $field): array
     {
         return [
             $namespace => [
@@ -142,11 +142,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-    public function sum($namespace,$field)
+    public function sum(string $namespace, string $field): array
     {
         return [
             $namespace => [
@@ -158,11 +158,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-    public function value_count($namespace,$field)
+    public function value_count(string $namespace, string $field): array
     {
         return [
             $namespace => [
@@ -174,12 +174,12 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @param bool $wrap_lon
      * @return array
      */
-    public function geo_bounds($namespace,$field,$wrap_lon=true)
+    public function geo_bounds(string $namespace, string $field, bool $wrap_lon = true): array
     {
         return [
             $namespace => [
@@ -192,11 +192,12 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $filter
+     * @param string $namespace
+     * @param array $filter
+     * @param array $aggs
      * @return array
      */
-    public function filter($namespace,$filter,$aggs)
+    public function filter(string $namespace,array $filter, array $aggs): array
     {
         return [
             $namespace => [
@@ -207,11 +208,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $filters
+     * @param string $namespace
+     * @param array $filters
      * @return array
      */
-    public function filters($namespace,$filters)
+    public function filters(string $namespace, array $filters): array
     {
         return [
             $namespace => [
@@ -223,12 +224,12 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
-     * @param $ranges
+     * @param string $namespace
+     * @param string $field
+     * @param array $ranges
      * @return array
      */
-    public function range($namespace,$field,$ranges)
+    public function range(string $namespace, string $field, array $ranges): array
     {
         return [
             $namespace => [
@@ -241,11 +242,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $type
+     * @param string $namespace
+     * @param string $type
      * @return array
      */
-    public function children($namespace,$type)
+    public function children(string $namespace, string $type): array
     {
         return [
             $namespace => [
@@ -257,15 +258,22 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
-     * @param $interval
-     * @param string $format
-     * @param string $timezone
-     * @param string $offset
+     * @param string $namespace
+     * @param string $field
+     * @param string $interval
+     * @param string|null $format
+     * @param string|null $timezone
+     * @param string|null $offset
      * @return array
      */
-    public function date_histogram($namespace,$field,$interval,$format=null,$timezone=null,$offset=null)
+    public function date_histogram(
+        string $namespace,
+        string $field,
+        string $interval,
+        string|null $format=null,
+        string|null $timezone=null,
+        string|null $offset=null
+    ): array
     {
         return [
             $namespace => [
@@ -281,56 +289,72 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
-     * @param $ranges
-     * @param string $format
+     * @param string $namespace
+     * @param string $field
+     * @param array $ranges
+     * @param string|null $format
+     * @param string|null $missing
      * @return array
      */
-    public function date_range($namespace,$field,$ranges,$format=null)
+    public function date_range(string $namespace, string $field, array $ranges, string $format = null, string $missing = null): array
     {
-        return [
+        $date_range = [
             $namespace => [
                 'date_range' => array_filter([
                     'field' => $field,
-                    'format' => $format,
                     'ranges' => $ranges
                 ])
             ]
         ];
+
+        if(!empty($format)){
+            $date_range[$namespace]['date_range']['format'] = $format;
+        }
+
+        if(!empty($missing)){
+            $date_range[$namespace]['date_range']['missing'] = $missing;
+        }
+
+        return $date_range;
     }
 
     /**
-     * @param $namespace
-     * @param $field
-     * @param $origin
-     * @param $ranges
-     * @param string $unit
+     * @param string $namespace
+     * @param string $field
+     * @param string $origin
+     * @param array $ranges
+     * @param string|null $unit
      * @return array
      */
-    public function geo_distance($namespace,$field,$origin,$ranges,$unit=null)
+    public function geo_distance(string $namespace, string $field, string $origin, array $ranges, string $unit=null): array
     {
-        return [
+
+        $geo_distance =  [
             $namespace => [
                 'geo_distance' => array_filter([
                     'field' => $field,
                     'origin' => $origin,
-                    'unit' => $unit,
                     'ranges' => $ranges
                 ])
             ]
         ];
+
+        if(!empty($unit)){
+            $geo_distance[$namespace]['geo_distance']['unit'] = $unit;
+        }
+
+        return $geo_distance;
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @param int $percision
      * @param int $size
      * @param int $shard_size
      * @return array
      */
-    public function geohash_grid($namespace,$field,$percision=2,$size=10000,$shard_size=0)
+    public function geohash_grid(string $namespace, string $field, int $percision = 2, int $size = 10000, int $shard_size = 0): array
     {
         return [
             $namespace => [
@@ -345,11 +369,14 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $aggs
+     * note: this is the global aggregation ... but can't use global as a function name (hence: "all")
+     *
+     *
+     * @param string $namespace
+     * @param array $aggs
      * @return array
      */
-    public function all($namespace,$aggs) //global aggregation ... but can't use global as a function name
+    public function all(string $namespace, array $aggs): array
     {
         return [
             $namespace => [
@@ -360,39 +387,51 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
-     * @param $interval
-     * @param null $minimum_doc_count
+     * @param string $namespace
+     * @param string $field
+     * @param int $interval
      * @param array $order
      * @param int $offset
-     * @param null $keyed
-     * @param null $missing
+     * @param bool|null $keyed
+     * @param int|string|null $missing
+     * @param int|null $minimum_doc_count
      * @return array
      */
-    public function histogram($namespace,$field,$interval,$order=['_key'=>'asc'],$offset=0,$keyed=null,$missing=null)
+    public function histogram(string $namespace, string $field, int $interval, array $order = ['_key' => 'asc'], int $offset = 0, bool|null $keyed = null, int|string $missing = null, int $minimum_doc_count = null): array
     {
 
-        return [
+        $histogram = [
             $namespace => [
                 'histogram' => array_filter([
                     'field' => $field,
                     'interval' => $interval,
                     'order' => $order,
-                    'offset' => $offset,
-                    'keyed' => $keyed,
-                    'missing' => $missing
+                    'offset' => $offset
                 ])
             ]
         ];
+
+        if(!empty($keyed)){
+            $histogram[$namespace]['histogram']['keyed'] = $keyed;
+        }
+
+        if(!empty($minimum_doc_count)){
+            $histogram[$namespace]['histogram']['min_doc_count'] = $minimum_doc_count;
+        }
+
+        if(!empty($minimum_doc_count)){
+            $histogram[$namespace]['histogram']['missing'] = $missing;
+        }
+
+        return $histogram;
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-    public function missing($namespace,$field)
+    public function missing(string $namespace, string $field): array
     {
         return [
             $namespace => [
@@ -404,12 +443,12 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $path
-     * @param $aggs
+     * @param string $namespace
+     * @param string $path
+     * @param array $aggs
      * @return array
      */
-    public function nested($namespace,$path,$aggs)
+    public function nested(string $namespace,string $path, array $aggs): array
     {
         return [
             $namespace => [
@@ -422,11 +461,11 @@ class Aggregation
     }
 
     /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-   public function significant_terms($namespace,$field)
+   public function significant_terms(string $namespace, string $field): array
    {
        return [
            $namespace => [
@@ -438,11 +477,11 @@ class Aggregation
    }
    
    /**
-     * @param $namespace
-     * @param $field
+     * @param string $namespace
+     * @param string $field
      * @return array
      */
-   public function significant_text($namespace,$field)
+   public function significant_text(string $namespace, string $field): array
    {
        return [
            $namespace => [
@@ -457,9 +496,10 @@ class Aggregation
      * @param string $namespace the aggregation's output namespace
      * @param array $values_source the sources of the values
      * @param int $size maximum number of composite buckets to be returned
-     * @return \array[][]
+     * @return array[][]
      */
-   public function composite($namespace, $values_source, $size = 10){
+   public function composite(string $namespace, array $values_source, int $size = 10): array
+   {
 
        return [
            $namespace => [

--- a/src/AggregationCompositeValuesSource.php
+++ b/src/AggregationCompositeValuesSource.php
@@ -28,9 +28,9 @@ class AggregationCompositeValuesSource
      *  https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-aggregations-bucket-daterange-aggregation.html#date-format-pattern
      * @param string $time_zone the time zone with which to adjust results
      * @param string $order the sort order of the source values
-     * @param bool $missing_bucket whether or not to include documents which are missing the resecptive source value
+     * @param bool $missing_bucket determines inclusion of documents which are missing the respective source value
      */
-    public function date_histogram($namespace, $field, $interval, $format = '', $time_zone = '', $order = 'asc', $missing_bucket = false)
+    public function date_histogram(string $namespace, string $field, string $interval, string $format = '', string $time_zone = '', string $order = 'asc', bool $missing_bucket = false)
     {
         $date_histogram = [
             $namespace => [
@@ -67,9 +67,10 @@ class AggregationCompositeValuesSource
      * @param string $field the field to be used for the values
      * @param string $interval the interval to be used to define the values
      * @param string $order the sort order of the source values
-     * @param bool $missing_bucket whether or not to include documents which are missing the resecptive source value
+     * @param bool $missing_bucket determines inclusion of documents which are missing the respective source value
+     * @return array
      */
-    public function histogram($namespace, $field, $interval, $order = 'asc', $missing_bucket = false)
+    public function histogram(string $namespace, string $field, string $interval, string $order = 'asc', bool $missing_bucket = false): array
     {
 
         $histogram = [
@@ -98,10 +99,10 @@ class AggregationCompositeValuesSource
      * @param string $namespace the namespace of the value source
      * @param string $field the field to be used for the values
      * @param string $order the sort order of the source values
-     * @param bool $missing_bucket whether or not to include documents which are missing the resecptive source value
+     * @param bool $missing_bucket determines inclusion of documents which are missing the respective source value
      * @return array
      */
-    public function terms($namespace, $field, $order = 'asc', $missing_bucket = false)
+    public function terms(string $namespace, string $field, string $order = 'asc', bool $missing_bucket = false): array
     {
         $terms = [
             $namespace => [

--- a/src/Eb.php
+++ b/src/Eb.php
@@ -23,7 +23,7 @@ class Eb extends Facade
      *
      * @return string
      */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'elasticbuilder';
     }

--- a/src/ElasticBuilderServiceProvider.php
+++ b/src/ElasticBuilderServiceProvider.php
@@ -14,7 +14,6 @@ namespace ElasticBuilder;
 use Illuminate\Support\ServiceProvider;
 use Elasticsearch\ClientBuilder as Builder;
 
-
 class ElasticBuilderServiceProvider extends ServiceProvider
 {
     /**
@@ -22,7 +21,7 @@ class ElasticBuilderServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
     }
@@ -32,7 +31,7 @@ class ElasticBuilderServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->app->bind('elasticbuilder', function() {
             return new ElasticBuilder(Builder::create()

--- a/src/ElasticBuilderTrait.php
+++ b/src/ElasticBuilderTrait.php
@@ -10,11 +10,12 @@
 
 namespace ElasticBuilder;
 
-use ElasticBuilder\Query\Boolean;
+use ElasticBuilder\Query\Boolean as QueryBoolean;
 use ElasticBuilder\Query\Boosting;
 use ElasticBuilder\Query\ConstantScore;
 use ElasticBuilder\Query\DisMax;
 use ElasticBuilder\Query\FunctionScore;
+use ElasticBuilder\Query\Query;
 
 /**
  * Class ElasticBuilderTrait
@@ -23,20 +24,22 @@ use ElasticBuilder\Query\FunctionScore;
 trait ElasticBuilderTrait
 {
     /**
-     * @param int|float $boost
+     * note: QueryBoolean is used here because "Boolean" is a reserved word in PHP, the interpreter was "having a fit"
+     *
+     * @param float|int $boost
      * @param int $minimum_should_match
-     * @return Query\Boolean
+     * @return QueryBoolean
      */
-    public function boolean($boost=1,$minimum_should_match=1)
+    public function boolean(float|int $boost=1, int $minimum_should_match = 1): QueryBoolean
     {
-        return new Boolean($boost,$minimum_should_match);
+        return new QueryBoolean($boost,$minimum_should_match);
     }
 
     /**
-     * @param int|float $boost
+     * @param float|int $boost
      * @return DisMax
      */
-    public function dis_max($boost=1)
+    public function dis_max(float|int $boost = 1): Dismax
     {
         return new DisMax($boost);
     }
@@ -44,7 +47,7 @@ trait ElasticBuilderTrait
     /**
      * @return Aggregation
      */
-    public function agg()
+    public function agg(): Aggregation
     {
         return new Aggregation;
     }
@@ -52,7 +55,7 @@ trait ElasticBuilderTrait
     /**
      * @return AggregationCompositeValuesSource
      */
-    public function aggCVS()
+    public function aggCVS(): AggregationCompositeValuesSource
     {
         return new AggregationCompositeValuesSource;
     }
@@ -60,38 +63,39 @@ trait ElasticBuilderTrait
     /**
      * @return Sort
      */
-    public function sort()
+    public function sort(): Sort
     {
         return new Sort;
     }
 
     /**
-     * @param int|float $negative_boost
+     * @param float|int $negative_boost
      * @return Boosting
      */
-    public function boosting($negative_boost=1)
+    public function boosting(float|int $negative_boost = 1): Boosting
     {
         return new Boosting($negative_boost);
     }
 
     /**
-     * @param int|float $boost
+     * @param float|int $boost
      * @return ConstantScore
      */
-    public function constant_score($boost=1)
+    public function constant_score(float|int $boost = 1)
     {
         return new ConstantScore($boost);
     }
     
     /**
-     * @param int|float|null $boost
-     * @param int|float|null $max_boost
+     * @param float|int|null $boost
+     * @param float|int|null $max_boost
      * @param string $boost_mode
-     * @param int|float|null $min_score
+     * @param float|int|null $min_score
      * @param string $score_mode
      * @return FunctionScore
      */
-    public function function_score($boost=null,$max_boost=null,$boost_mode='multiply',$min_score=null,$score_mode='multiply'){
+    public function function_score(float|int|null $boost=null, float|int|null $max_boost = null, string $boost_mode = 'multiply', float|int|null $min_score=null, string $score_mode = 'multiply'): FunctionScore
+    {
         return new FunctionScore($boost,$max_boost,$boost_mode,$min_score,$score_mode);
     }
 }

--- a/src/Query/Boolean.php
+++ b/src/Query/Boolean.php
@@ -22,7 +22,7 @@ class Boolean extends Query
      * @param int $boost
      * @param int $minimum_should_match
      */
-    public function __construct($boost=1,$minimum_should_match=1)
+    public function __construct( int $boost=1, int $minimum_should_match=1)
     {
         $this->query = ['bool'=>['boost'=>$boost,'minimum_should_match'=>$minimum_should_match]];
     }

--- a/src/Query/Boosting.php
+++ b/src/Query/Boosting.php
@@ -18,26 +18,26 @@ class Boosting
      * Boosting constructor.
      * @param int $negative_boost
      */
-    public function __construct($negative_boost=1)
+    public function __construct(int $negative_boost = 1)
     {
         $this->query = ['boosting'=>['negative_boost'=>$negative_boost]];
     }
 
     /**
-     * @param $query
+     * @param array $query
      * @return $this
      */
-    public function positive($query)
+    public function positive(array $query): Boosting
     {
         $this->query['boosting']['positive'] = array_merge_recursive(($this->query['boosting']['positive'] ?? []), $query);
         return $this;
     }
 
     /**
-     * @param $query
+     * @param array $query
      * @return $this
      */
-    public function negative($query)
+    public function negative(array $query): Boosting
     {
         $this->query['boosting']['negative'] = array_merge_recursive(($this->query['boosting']['negative'] ?? []), $query);
         return $this;

--- a/src/Query/ConstantScore.php
+++ b/src/Query/ConstantScore.php
@@ -16,18 +16,22 @@ class ConstantScore extends Query
 {
     /**
      * ConstantScore constructor.
-     * @param int|float|null $boost
+     * @param float|int|null $boost
      */
-    public function __construct($boost=1)
+    public function __construct(float|int|null $boost = 1)
     {
-        $this->query = ['constant_score'=>['boost'=>$boost]];
+        $this->query = [
+            'constant_score' => [
+                'boost' => $boost
+            ]
+        ];
     }
 
     /**
-     * @param $filter
+     * @param array $filter
      * @return $this
      */
-    public function filter($filter)
+    public function filter(array $filter): ConstantScore
     {
         $this->query['constant_score']['filter'] = array_merge_recursive(($this->query['constant_score']['filter'] ?? []), $filter);
         return $this;

--- a/src/Query/DisMax.php
+++ b/src/Query/DisMax.php
@@ -19,29 +19,35 @@ class DisMax extends Query
     /**
      * @var
      */
-    protected $queries; //the queries portion of the dis_max query
+    protected array $queries; //the queries portion of the dis_max query
 
     /**
      * DisMax constructor.
      * @param int $boost
      */
-    public function __construct($boost=1)
+    public function __construct(int $boost = 1)
     {
-        $this->query = ['dis_max'=>['boost'=>$boost]];
+        $this->query = [
+            'dis_max' => [
+                'boost' => $boost
+            ]
+        ];
     }
 
     /**
-     * @param $query
+     * @param array $query
+     * @return void
      */
-    public function query($query)
+    public function query(array $query): void
     {
         $this->query['dis_max']['queries'] = array_merge_recursive(($this->query['dis_max']['queries'] ?? []), $query);
     }
 
     /**
      * @param array $queries
+     * @return void
      */
-    public function queries($queries=[])
+    public function queries(array $queries=[]): void
     {
         $this->query['dis_max']['queries'] = $queries;
     }

--- a/src/Query/FunctionScore.php
+++ b/src/Query/FunctionScore.php
@@ -17,13 +17,13 @@ class FunctionScore extends Query
     /**
      * FunctionScore constructor.
      *
-     * @param int|float|null $boost boost for the given query
-     * @param int|float|null $max_boost the maximum boost allowed to be applied
+     * @param float|int|null $boost boost for the given query
+     * @param float|int|null $max_boost the maximum boost allowed to be applied
      * @param string $boost_mode how the function_score score is combined with the query score
-     * @param int|float|null $min_score the minimum score threshold for a document to count as a result
+     * @param float|int|null $min_score the minimum score threshold for a document to count as a result
      * @param string $score_mode how the function_score score is computed
      */
-    public function __construct($boost=null,$max_boost=null,$boost_mode='multiply',$min_score=null,$score_mode='multiply')
+    public function __construct(float|int|null $boost = null,float|int|null $max_boost = null, string $boost_mode='multiply', float|int|null $min_score = null, string $score_mode = 'multiply')
     {
         $this->query = [
             'function_score'=>[],
@@ -54,19 +54,20 @@ class FunctionScore extends Query
      * @param array $query
      * @return $this
      */
-    public function query($query=[]){
+    public function query(array $query = []): FunctionScore
+    {
         $this->query['function_score']['query'] = $query;
         return $this;
     }
 
     /**
      * @param array $filter the function filter which are used to score
-     * @param int|float|null $weight the score applied to this function
+     * @param float|int|null $weight the score applied to this function
      * @param string $score_function_name the name of the scoring function used for this filter (when applicable)
      * @param array $score_function_body the body of the scoring function used for this filter (when applicable)
      * @return $this
      */
-    public function functions_filter($filter,$weight=null,$score_function_name='',$score_function_body=[])
+    public function functions_filter(array $filter, float|int|null $weight = null, string $score_function_name = '', array $score_function_body = [])
     {
         $new_filter = ['filter' => $filter];
 
@@ -92,12 +93,12 @@ class FunctionScore extends Query
      * @param mixed $origin note: Required (by Elasticsearch) for Geo and Numeric Field Types
      * @param string $offset if set, the decay function will only begin computing decay functions with distances greater than the offset
      * @param string $decay how documents are scored at the distance provided via scale
-     * @param int|float|null $weight the score applied to this function
+     * @param float|int|null $weight the score applied to this function
      * @param string $multiValueMode if more than one origin is given, this value is used to determine the distance ('min'|'max'|'avg'|'sum')
      * @param array $filters additional criteria to filter the decay function by
      * @return FunctionScore
      */
-    private function functions_decay($decayFunction, $field, $scale, $origin = '', $offset = '', $decay = '', $weight = null, $multiValueMode = 'min', $filters = [])
+    private function functions_decay(string $decayFunction, string $field, string $scale, string $origin = '', string $offset = '', string $decay = '',  float|int|null $weight = null, string $multiValueMode = 'min', array $filters = []): FunctionScore
     {
         $new_decay = [
             $decayFunction => [
@@ -138,12 +139,12 @@ class FunctionScore extends Query
      * @param mixed $origin note: Required (by Elasticsearch) for Geo and Numeric Field Types
      * @param string $offset if set, the decay function will only begin computing decay functions with distances greater than the offset
      * @param string $decay how documents are scored at the distance provided via scale
-     * @param int|float|null $weight the score applied to this function
+     * @param float|int|null $weight the score applied to this function
      * @param string $multiValueMode if more than one origin is given, this value is used to determine the distance ('min'|'max'|'avg'|'sum')
      * @param array $filters additional criteria to filter the gaussian decay function by
      * @return FunctionScore
      */
-    public function gauss($field,$scale,$origin = '',$offset = '0',$decay = '0.5', $weight = null, $multiValueMode = 'min', $filters = [])
+    public function gauss(string $field, string $scale, mixed $origin = '', string $offset = '0', string $decay = '0.5', float|int|null $weight = null, string $multiValueMode = 'min', array $filters = [])
     {
 
         return $this->functions_decay('gauss', $field, $scale, $origin, $offset, $decay, $weight, $multiValueMode, $filters);
@@ -158,12 +159,12 @@ class FunctionScore extends Query
      * @param mixed $origin note: Required (by Elasticsearch) for Geo and Numeric Field Types
      * @param string $offset if set, the decay function will only begin computing decay functions with distances greater than the offset
      * @param string $decay how documents are scored at the distance provided via scale
-     * @param int|float|null $weight the score applied to this function
+     * @param float|int|null $weight the score applied to this function
      * @param string $multiValueMode if more than one origin is given, this value is used to determine the distance ('min'|'max'|'avg'|'sum')
      * @param array $filters additional criteria to filter the exponential decay function by
      * @return FunctionScore
      */
-    public function exp($field,$scale,$origin = '',$offset = '0',$decay = '0.5', $weight = null, $multiValueMode = 'min', $filters = [])
+    public function exp(string $field, string $scale, mixed $origin = '', string $offset = '0', string $decay = '0.5', float|int|null $weight = null, string $multiValueMode = 'min', array $filters = []): FunctionScore
     {
 
         return $this->functions_decay('exp', $field, $scale, $origin, $offset, $decay, $weight, $multiValueMode, $filters);
@@ -178,12 +179,12 @@ class FunctionScore extends Query
      * @param mixed $origin note: Required (by Elasticsearch) for Geo and Numeric Field Types
      * @param string $offset if set, the decay function will only begin computing decay functions with distances greater than the offset
      * @param string $decay how documents are scored at the distance provided via scale
-     * @param int|float|null $weight the score applied to this function
+     * @param float|int|null $weight the score applied to this function
      * @param string $multiValueMode if more than one origin is given, this value is used to determine the distance ('min'|'max'|'avg'|'sum')
      * @param array $filters additional criteria to filter the linear decay function by
      * @return FunctionScore
      */
-    public function linear($field,$scale,$origin = '',$offset = '0',$decay = '0.5', $weight = null, $multiValueMode = 'min', $filters = [])
+    public function linear(string $field, string $scale, mixed $origin = '', string $offset = '0', string $decay = '0.5', float|int|null $weight = null, string $multiValueMode = 'min', array $filters = []): FunctionScore
     {
 
         return $this->functions_decay('linear', $field, $scale, $origin, $offset, $decay, $weight, $multiValueMode, $filters);

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -19,62 +19,62 @@ abstract class Query
     /**
      * @var array aggregations to execute along with the query
      */
-    protected $aggregations = [];
+    protected array $aggregations = [];
 
     /**
      * @var array sorts to be passed along with the query
      */
-    protected $sorts = [];
+    protected array $sorts = [];
 
     /**
      * @var array the full query ... it's a bool
      */
-    protected $query;
+    protected array $query;
 
     /**
      * @var
      */
-    protected $model;
+    protected mixed $model;
 
     /**
-     * @return mixed
+     * @return array
      */
-    public function get()
+    public function get(): array
     {
         return $this->query;
     }
     
     /**
-     * @return mixed
+     * @return array
      */
-    public function aggregations()
+    public function aggregations(): array
     {
         return $this->aggregations;
     }
     
     /**
-     * @return mixed
+     * @return array
      */
-    public function sorts()
+    public function sorts(): array
     {
         return $this->sorts;
     }
 
     /**
-     * @param $agg
+     * @param array $agg
      * @return $this
      */
-    public function aggregate(Array $agg)
+    public function aggregate(array $agg): Query
     {
         $this->aggregations = array_merge($this->aggregations,$agg);
         return $this;
     }
 
     /**
-     * @param $sort
+     * @param array $sort
      * @return $this
      */
-    public function sort(Array $sort)
+    public function sort(array $sort): Query
     {
         $this->sorts = array_merge($this->sorts,$sort);
         return $this;
@@ -83,7 +83,7 @@ abstract class Query
     /**
      * @return string
      */
-    public function toJson()
+    public function toJson(): string
     {
         return json_encode($this->get());
     }

--- a/src/Sort.php
+++ b/src/Sort.php
@@ -18,13 +18,13 @@ class Sort
 {
 
     /**
-     * @param $field the field to sort on
+     * @param string $field the field to sort on
      * @param string $order the order of results -- asc (ascending) or desc (descending)
      * @param string $mode when sorting by array values, determinant of which array value is chosen when sorting the respective document (min, max, sum, avg, median)
      * @param string $missing_values what to do with docs which are missing the respective sort field (_last, _first, or a custom value to be used by missing docs as their sort value)
      * @param string $unmapped_type what sort values to emit if the respective field is not mapped
      */
-    public function byField($field, $order = 'asc', $mode = '', $missing = '', $unmapped_type = '')
+    public function byField(string $field, string $order = 'asc', string $mode = '', string $missing = '', string $unmapped_type = ''): array
     {
         $sort = [
             $field => [
@@ -52,22 +52,22 @@ class Sort
      * @param string $order the order of results -- asc (ascending) or desc (descending)
      * @return array
      */
-    public function byScore( $order = 'desc' )
+    public function byScore( string $order = 'desc' ): array
     {
         return $this->byField('_score', $order);
     }
 
     /**
      * @param string $field the name of the property-field with the location data
-     * @param $origin the point of origin to begin calculation distance
+     * @param array $origin the point of origin to begin calculation distance
      * @param string $unit the unit of measure to determine distance by (ex: mi, km, m)
      * @param string $order the order of results -- asc (ascending) or desc (descending)
      * @param string $distance_type how to measure the distance (arc or plane)
      * @param string $mode how to handle a field with multiple geo points
-     * @param boolean $ignore_unmapped should the unmapped field be treated as a missing value?
+     * @param bool $ignore_unmapped should the unmapped field be treated as a missing value?
      * @param string $origin_format how to build the field data in the request (ex: array,geohash,multiple_reference_points,properties,string)
      */
-    public function byGeoDistance($field, $origin, $unit = 'm', $order = 'asc', $mode = 'min', $distance_type = 'arc', $ignore_unmapped = false, $origin_format = 'array')
+    public function byGeoDistance(string $field, array $origin, string $unit = 'm', string $order = 'asc', string $mode = 'min', string $distance_type = 'arc', bool $ignore_unmapped = false, string $origin_format = 'array'): array
     {
         //options which are handled by "byField" (a.k.a. not unique to _geo_distance sorting)
 


### PR DESCRIPTION
* add types in PHP doc blocks
* add type hinting to parameters (PHP 8.0+ only because of union type hinting)
* add return type class functions
* fix issue with multi_match function query parameter. it was accepting array, but according to Elasticsearch the query parameter for multi_match is a string (src/ElasticBuilder.php)
* fix optional parameters before required parameters php 8.0 compatibility issues